### PR TITLE
Add view-all-forum-threads view

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,8 +1,10 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { channelDiscussionThreads } from './channel-discussion-threads';
 import { triggeredActionIntegrationDiscourseMirrorEvent } from './triggered-action-integration-discourse-mirror-event';
+import { viewAllForumThreads } from './view-all-forum-threads';
 
 export const contracts: ContractDefinition[] = [
 	channelDiscussionThreads,
 	triggeredActionIntegrationDiscourseMirrorEvent,
+	viewAllForumThreads,
 ];

--- a/lib/contracts/view-all-forum-threads.ts
+++ b/lib/contracts/view-all-forum-threads.ts
@@ -1,0 +1,93 @@
+import type { ViewContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const viewAllForumThreads: ViewContractDefinition = {
+	slug: 'view-all-forum-threads',
+	name: 'Forums',
+	type: 'view@1.0.0',
+	markers: ['org-balena'],
+	loop: 'loop-balena-io@1.0.0',
+	data: {
+		namespace: 'Support',
+		allOf: [
+			{
+				name: 'Forum threads',
+				schema: {
+					anyOf: [
+						{
+							$$links: {
+								'is owned by': {
+									type: 'object',
+									required: ['type'],
+									properties: {
+										type: {
+											const: 'user@1.0.0',
+										},
+									},
+								},
+							},
+						},
+						true,
+					],
+					$$links: {
+						'has attached element': {
+							type: 'object',
+							properties: {
+								type: {
+									enum: [
+										'message@1.0.0',
+										'create@1.0.0',
+										'whisper@1.0.0',
+										'update@1.0.0',
+										'rating@1.0.0',
+										'summary@1.0.0',
+									],
+								},
+							},
+							additionalProperties: true,
+						},
+					},
+					type: 'object',
+					properties: {
+						active: {
+							const: true,
+							type: 'boolean',
+						},
+						type: {
+							type: 'string',
+							const: 'support-thread@1.0.0',
+						},
+						data: {
+							type: 'object',
+							required: ['inbox', 'mirrors'],
+							properties: {
+								inbox: {
+									type: 'string',
+									not: {
+										const: 'Discussions',
+									},
+								},
+								mirrors: {
+									type: 'array',
+									items: {
+										type: 'string',
+										pattern: 'forums.balena.io',
+									},
+								},
+								category: {
+									description:
+										"This field is not required and should match cases where the field is not present OR is 'general'",
+									const: 'general',
+								},
+								product: {
+									const: 'balenaCloud',
+								},
+							},
+						},
+					},
+					required: ['active', 'type', 'data'],
+					additionalProperties: true,
+				},
+			},
+		],
+	},
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -20,7 +20,7 @@ export const discoursePlugin = (): PluginDefinition => {
 		requires: [
 			{
 				slug: 'plugin-default',
-				version: '>=23.x',
+				version: '>=24.x',
 			},
 			{
 				slug: 'plugin-channels',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@balena/jellyfish-config": "^2.0.2",
     "@balena/jellyfish-environment": "^9.1.2",
     "@balena/jellyfish-plugin-channels": "^2.0.42",
-    "@balena/jellyfish-plugin-default": "^23.3.26",
+    "@balena/jellyfish-plugin-default": "^24.0.0",
     "@balena/jellyfish-plugin-product-os": "^4.0.38",
     "@balena/jellyfish-types": "^2.0.4",
     "@balena/lint": "^6.2.0",


### PR DESCRIPTION
Moving from plugin-default as this view
is specific to discourse forum threads.

Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Depends on:
- https://github.com/product-os/jellyfish-plugin-default/pull/1013