### PR TITLE
Exclude blog discussions from forum support view

### DIFF
--- a/lib/contracts/view-all-forum-threads.ts
+++ b/lib/contracts/view-all-forum-threads.ts
@@ -60,6 +60,12 @@ export const viewAllForumThreads: ViewContractDefinition = {
 							type: 'object',
 							required: ['mirrors'],
 							properties: {
+								inbox: {
+									not: {
+										type: 'string',
+										const: 'Discussions',
+									},
+								},
 								mirrors: {
 									type: 'array',
 									items: {


### PR DESCRIPTION
We have a blog discussions channel specifically for
these threads and they are not really support.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>