### PR TITLE
Improve performance of mirror triggered actions

### DIFF
--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,10 +1,12 @@
 import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
 import { channelDiscussionThreads } from './channel-discussion-threads';
 import { triggeredActionIntegrationDiscourseMirrorEvent } from './triggered-action-integration-discourse-mirror-event';
+import { triggeredActionIntegrationDiscourseMirrorThread } from './triggered-action-integration-discourse-mirror-thread';
 import { viewAllForumThreads } from './view-all-forum-threads';
 
 export const contracts: ContractDefinition[] = [
 	channelDiscussionThreads,
 	triggeredActionIntegrationDiscourseMirrorEvent,
+	triggeredActionIntegrationDiscourseMirrorThread,
 	viewAllForumThreads,
 ];

--- a/lib/contracts/triggered-action-integration-discourse-mirror-event.ts
+++ b/lib/contracts/triggered-action-integration-discourse-mirror-event.ts
@@ -10,18 +10,18 @@ export const triggeredActionIntegrationDiscourseMirrorEvent: ContractDefinition 
 			schedule: 'sync',
 			filter: {
 				type: 'object',
-				anyOf: [
-					{
-						required: ['type'],
-						properties: {
-							type: {
-								type: 'string',
-								enum: ['message@1.0.0', 'whisper@1.0.0'],
-							},
-						},
+				properties: {
+					type: {
+						type: 'string',
+						enum: ['message@1.0.0', 'whisper@1.0.0'],
 					},
-					{
-						required: ['type', 'data', 'name'],
+					data: {
+						type: 'object',
+					},
+				},
+				$$links: {
+					'is attached to': {
+						type: 'object',
 						properties: {
 							type: {
 								type: 'string',
@@ -29,13 +29,20 @@ export const triggeredActionIntegrationDiscourseMirrorEvent: ContractDefinition 
 							},
 							data: {
 								type: 'object',
-							},
-							name: {
-								type: 'string',
+								required: ['mirrors'],
+								properties: {
+									mirrors: {
+										type: 'array',
+										contains: {
+											type: 'string',
+											pattern: '^https://forums.balena.io',
+										},
+									},
+								},
 							},
 						},
 					},
-				],
+				},
 			},
 			action: 'action-integration-discourse-mirror-event@1.0.0',
 			target: {

--- a/lib/contracts/triggered-action-integration-discourse-mirror-thread.ts
+++ b/lib/contracts/triggered-action-integration-discourse-mirror-thread.ts
@@ -1,0 +1,44 @@
+import type { ContractDefinition } from '@balena/jellyfish-types/build/core';
+
+export const triggeredActionIntegrationDiscourseMirrorThread: ContractDefinition =
+	{
+		slug: 'triggered-action-integration-discourse-mirror-thread',
+		type: 'triggered-action@1.0.0',
+		name: 'Triggered action for Discourse mirrors',
+		markers: [],
+		data: {
+			filter: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string',
+					},
+					type: {
+						type: 'string',
+						const: 'support-thread@1.0.0',
+					},
+					data: {
+						type: 'object',
+						required: ['mirrors'],
+						properties: {
+							mirrors: {
+								type: 'array',
+								contains: {
+									type: 'string',
+									pattern: '^https://forums.balena.io',
+								},
+							},
+							tags: {
+								type: 'array',
+							},
+						},
+					},
+				},
+			},
+			action: 'action-integration-discourse-mirror-event@1.0.0',
+			target: {
+				$eval: 'source.id',
+			},
+			arguments: {},
+		},
+	};


### PR DESCRIPTION
This change splits the existing triggered action into two, with much
more specific filters that prevent the integration running unnecessarily
on non-discourse threads.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>